### PR TITLE
Minor text tweaks in carrot readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,10 +6,9 @@ A synchronous amqp client. Based on Aman's amqp client:
 
 ## Motivation
 
-This client does not use eventmachine so no background thread necessary. As a result, it is much easier to use from script/console and Passenger. It also solves the problem of buffering messages and ack responses. For more details see [this thread](http://groups.google.com/group/ruby-amqp/browse_thread/thread/fdae324a0ebb1961/fa185fdce1841b68).
+This client does not use eventmachine so no background thread is necessary. As a result, it is much easier to use from script/console and Passenger. It also solves the problem of buffering messages and ack responses. For more details see [this thread](http://groups.google.com/group/ruby-amqp/browse_thread/thread/fdae324a0ebb1961/fa185fdce1841b68).
 
 There is currently no way to prevent buffering using eventmachine. Support for prefetch is still unreliable.
-
 
 ## Examples
     
@@ -29,6 +28,7 @@ There is currently no way to prevent buffering using eventmachine. Support for p
     end
     Carrot.stop
     
+
 ### Using options with server and queue
 
     require 'carrot'

--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ A synchronous amqp client. Based on Aman's amqp client:
 
 ## Motivation
 
-This client does not use eventmachine so no background thread is necessary. As a result, it is much easier to use from script/console and Passenger. It also solves the problem of buffering messages and ack responses. For more details see [this thread](http://groups.google.com/group/ruby-amqp/browse_thread/thread/fdae324a0ebb1961/fa185fdce1841b68).
+This client does not use eventmachine so no background thread is necessary. As a result, it is much easier to use from script/console and [Passenger](https://www.phusionpassenger.com/). It also solves the problem of buffering messages and ack responses. For more details see [this thread](http://groups.google.com/group/ruby-amqp/browse_thread/thread/fdae324a0ebb1961/fa185fdce1841b68).
 
 There is currently no way to prevent buffering using eventmachine. Support for prefetch is still unreliable.
 


### PR DESCRIPTION
* Add missing word(s)
* Make blank line usage consistent around header lines
* Make Passenger mention a link so the other docs are easier to find